### PR TITLE
fix(perf): use HTMLRewriter instead of regex for html transformation

### DIFF
--- a/src/__csp-nonce-inputs.json
+++ b/src/__csp-nonce-inputs.json
@@ -1,3 +1,1 @@
-{
-  "reportOnly": false
-}
+{}

--- a/src/__csp-nonce-inputs.json
+++ b/src/__csp-nonce-inputs.json
@@ -1,1 +1,3 @@
-{}
+{
+  "reportOnly": false
+}


### PR DESCRIPTION
This PR uses WASM-based https://workers.tools/html-rewriter/ instead of a regular expression to perform the HTML body transformation, which simplifies code and should give a minor perf boost. Closes #45 

Tested on https://deploy-preview-18839--app.netlify.com, as well as https://deploy-preview-48--csp-nonce.netlify.app!