### PR TITLE
fix(perf): join excluded extensions into one regex instead of spreading into multiple regexes

### DIFF
--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -175,7 +175,7 @@ export const config: Config = {
   excludedPath: [
     ...params.excludedPath,
     "/.netlify/*",
-    ...excludedExtensions.map((ext) => `**/*.${ext}`),
+    `**/*.(${excludedExtensions.join("|")})`,
   ],
   handler,
   onError: "bypass",


### PR DESCRIPTION
This PR simplifies the excludedPaths regexes by joining all of the excluded extensions into a single regex, vs spreading them into multiple. In turns out that joining all into a single regex is much more performant ([Slack thread](https://netlify.slack.com/archives/C0183KVDHFH/p1692831720217969?thread_ts=1692696298.268039&cid=C0183KVDHFH)). Closes #46 

To test, go to https://deploy-preview-49--csp-nonce.netlify.app, and with a clean/fresh browser cache, inspect the response headers for the document html, and for the 404ing favicon.ico. The document html should have the `x-debug-csp-nonce: invoked` response header, whereas the favicon.ico resource should not. 

You can try this on https://deploy-preview-18839--app.netlify.com too -- only the document html should have `x-debug-csp-nonce: invoked`, and not any of the other JS/CSS/etc assets. 