### PR TITLE
fix: excludedPath not iterable

### DIFF
--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -178,7 +178,7 @@ export const config: Config = {
   excludedPath: [
     "/.netlify/*",
     `**/*.(${excludedExtensions.join("|")})`,
-  ].concat(params.excludedPath),
+  ].concat(params.excludedPath).filter(Boolean),
   handler,
   onError: "bypass",
 };

--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -176,10 +176,9 @@ const excludedExtensions = [
 export const config: Config = {
   path: params.path,
   excludedPath: [
-    ...params.excludedPath,
     "/.netlify/*",
     `**/*.(${excludedExtensions.join("|")})`,
-  ],
+  ].concat(params.excludedPath),
   handler,
   onError: "bypass",
 };

--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -175,10 +175,9 @@ const excludedExtensions = [
 
 export const config: Config = {
   path: params.path,
-  excludedPath: [
-    "/.netlify/*",
-    `**/*.(${excludedExtensions.join("|")})`,
-  ].concat(params.excludedPath).filter(Boolean),
+  excludedPath: ["/.netlify/*", `**/*.(${excludedExtensions.join("|")})`]
+    .concat(params.excludedPath)
+    .filter(Boolean),
   handler,
   onError: "bypass",
 };


### PR DESCRIPTION
We saw an error in a user's deploy (helpdesk ticket: https://netlify.zendesk.com/agent/tickets/200248) that said:

```
Packaging Edge Functions from netlify/edge-functions directory:
  - __csp-nonce
 TypeError: params.excludedPath is not iterable
     at file:///opt/build/repo/netlify/edge-functions/__csp-nonce.ts:179:15
```

Looking at the code, the types for `params.excludedPath` say it can be a `string | Array<string>`. In case the property is a string, `...params.excludedPath` would simply make the string unusable for the config. For example:

```ts
const foo = 'bar'
console.log(...foo) // b a r
```

Since we need an array, I think it's best to just concat the 2 arrays (or an array and a string) together as they'd both produce the expected results.

Any thoughts?