### PR TITLE
fix: add nonce to link preload tags

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -2,11 +2,12 @@
 <html>
   <head>
     <title>Using CSP Nonces on Script Tags</title>
-    <style>
-      body {
-        font-family: sans-serif;
-      }
-    </style>
+    <link rel="stylesheet" href="/main.css" />
+    <link
+      rel="preload"
+      as="script"
+      href="https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js"
+    />
   </head>
   <body>
     <h1>Using CSP Nonces on Script Tags</h1>
@@ -40,7 +41,7 @@
           "ipt>" +
           "document.write('<div>❌ Script tag from <code>document.write</code> has executed!</div>');" +
           "</scr" +
-          "ipt>"
+          "ipt>",
       );
     </script>
     <script>

--- a/site/main.css
+++ b/site/main.css
@@ -1,0 +1,3 @@
+body {
+  font-family: sans-serif;
+}

--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -112,8 +112,9 @@ const handler = async (request: Request, context: Context) => {
     response.headers.set(header, value);
   }
 
+  const querySelectors = ["script", 'link[rel="preload"][as="script"]'];
   return new HTMLRewriter()
-    .on("script", {
+    .on(querySelectors.join(","), {
       element(element: HTMLElement) {
         element.setAttribute("nonce", nonce);
       },


### PR DESCRIPTION
This PR fixes #58 by also adding the nonce to `<link rel="preload" as="script" />` elements. It also adds a case to the site's index.html file so that we can test that it is indeed adding the nonce in the site's Deploy Previews. 