### PR TITLE
fix: use functions-internal to ensure frameworks do not remove edge function we generate

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,16 @@ import fs, { copyFileSync } from "fs";
 
 const SITE_ID = "321a7119-6008-49a8-9d2f-e20602b1b349";
 
-export const onPreBuild = async ({ inputs, netlifyConfig, utils }) => {
+export const onPreBuild = async ({
+  inputs,
+  netlifyConfig,
+  utils,
+  constants,
+}) => {
   const config = JSON.stringify(inputs, null, 2);
   const { build } = netlifyConfig;
+
+  const { INTERNAL_EDGE_FUNCTIONS_SRC, INTERNAL_FUNCTIONS_SRC } = constants;
 
   // DISABLE_CSP_NONCE is undocumented (deprecated), but still supported
   // -> superseded by CSP_NONCE_DISTRIBUTION
@@ -35,25 +42,30 @@ export const onPreBuild = async ({ inputs, netlifyConfig, utils }) => {
       ? "./src"
       : "./node_modules/@netlify/plugin-csp-nonce/src";
 
-  const edgeFunctionsDir = build.edge_functions || "./netlify/edge-functions";
   // make the directory in case it actually doesn't exist yet
-  await utils.run.command(`mkdir -p ${edgeFunctionsDir}`);
-  console.log(`  Writing nonce edge function to ${edgeFunctionsDir}...`);
+  await utils.run.command(`mkdir -p ${INTERNAL_EDGE_FUNCTIONS_SRC}`);
+  console.log(
+    `  Writing nonce edge function to ${INTERNAL_EDGE_FUNCTIONS_SRC}...`,
+  );
   copyFileSync(
     `${basePath}/__csp-nonce.ts`,
-    `${edgeFunctionsDir}/__csp-nonce.ts`
+    `${INTERNAL_EDGE_FUNCTIONS_SRC}/__csp-nonce.ts`,
   );
-  fs.writeFileSync(`${edgeFunctionsDir}/__csp-nonce-inputs.json`, config);
+  fs.writeFileSync(
+    `${INTERNAL_EDGE_FUNCTIONS_SRC}/__csp-nonce-inputs.json`,
+    config,
+  );
 
   // if no reportUri in config input, deploy function on site's behalf
   if (!inputs.reportUri) {
-    const functionsDir = build.functions || "./netlify/functions";
     // make the directory in case it actually doesn't exist yet
-    await utils.run.command(`mkdir -p ${functionsDir}`);
-    console.log(`  Writing violations logging function to ${functionsDir}...`);
+    await utils.run.command(`mkdir -p ${INTERNAL_FUNCTIONS_SRC}`);
+    console.log(
+      `  Writing violations logging function to ${INTERNAL_FUNCTIONS_SRC}...`,
+    );
     copyFileSync(
       `${basePath}/__csp-violations.ts`,
-      `${functionsDir}/__csp-violations.ts`
+      `${INTERNAL_FUNCTIONS_SRC}/__csp-violations.ts`,
     );
   } else {
     console.log(`  Using ${inputs.reportUri} as report-uri directive...`);


### PR DESCRIPTION
Use build constants to determine the function directory where the functions should be written