### PR TITLE
fix: remove trailing slash from .netlify excluded path

### DIFF
--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -179,7 +179,7 @@ const excludedExtensions = [
 
 export const config: Config = {
   path: params.path,
-  excludedPath: ["/.netlify/*", `**/*.(${excludedExtensions.join("|")})`]
+  excludedPath: ["/.netlify*", `**/*.(${excludedExtensions.join("|")})`]
     .concat(params.excludedPath)
     .filter(Boolean),
   handler,


### PR DESCRIPTION
This fixes an issue where the edge function would be invoked if the path was encoded like `/.netlify%2Ffunctions/`. 