### PR TITLE
fix: upgrade html_rewriter

### DIFF
--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -4,7 +4,7 @@ import type { Config, Context } from "netlify:edge";
 // @ts-ignore
 import { randomBytes } from "node:crypto";
 // @ts-ignore
-import { HTMLRewriter } from "https://ghuc.cc/worker-tools/html-rewriter@0.1.0-pre.17/index.ts";
+import { HTMLRewriter } from "https://ghuc.cc/worker-tools/html-rewriter@0.1.0-pre.19/index.ts";
 
 // @ts-ignore
 import inputs from "./__csp-nonce-inputs.json" assert { type: "json" };


### PR DESCRIPTION
See https://github.com/worker-tools/html-rewriter/issues/6. We suspect that html_rewriter has a memory leak on high usage, and with a bit of luck this dependency upgrade fixes it.

Part of https://linear.app/netlify/issue/COM-687/new-relic-or-edge-functions-failing-w-error-recursive-use-of-an-object.