### PR TITLE
fix(perf): return early if the request is not a HTTP GET

### DIFF
--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -19,7 +19,7 @@ type Params = {
 const params = inputs as Params;
 
 const handler = async (request: Request, context: Context) => {
-  const isGET = request.method.toUpperCase() === "GET";
+  const isGET = request.method === "GET";
   // We only need to run this for HTTP GET requests.
   // If it is not a GET, then return early.
   //

--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -19,6 +19,24 @@ type Params = {
 const params = inputs as Params;
 
 const handler = async (request: Request, context: Context) => {
+  const isGET = request.method.toUpperCase() === "GET";
+  // We only need to run this for HTTP GET requests.
+  // If it is not a GET, then return early.
+  //
+  // If we instead used `context.next(request)`
+  // we would be passing the request through this 
+  // edge function for no useful reason.
+  if (!isGET) {
+    console.log(`Unnecessary invocation for ${request.url}`, {
+      method: request.method,
+    });
+    return;
+  }
+
+
+  // At this point, we know it's a GET request,
+  // we have to now make the request, in order to
+  // see what the HTTP response's content-type is.
   const response = await context.next(request);
 
   let header = params.reportOnly
@@ -28,12 +46,10 @@ const handler = async (request: Request, context: Context) => {
   // for debugging which routes use this edge function
   response.headers.set("x-debug-csp-nonce", "invoked");
 
-  // html GETs only
-  const isGET = request.method?.toUpperCase() === "GET";
   const isHTMLResponse = response.headers
     .get("content-type")
     ?.startsWith("text/html");
-  const shouldTransformResponse = isGET && isHTMLResponse;
+  const shouldTransformResponse = isHTMLResponse;
   if (!shouldTransformResponse) {
     console.log(`Unnecessary invocation for ${request.url}`, {
       method: request.method,
@@ -180,8 +196,8 @@ const excludedExtensions = [
 export const config: Config = {
   path: params.path,
   excludedPath: ["/.netlify*", `**/*.(${excludedExtensions.join("|")})`]
-    .concat(params.excludedPath)
-    .filter(Boolean),
+  .concat(params.excludedPath)
+  .filter(Boolean),
   handler,
   onError: "bypass",
 };

--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -27,9 +27,6 @@ const handler = async (request: Request, context: Context) => {
   // we would be passing the request through this 
   // edge function for no useful reason.
   if (!isGET) {
-    console.log(`Unnecessary invocation for ${request.url}`, {
-      method: request.method,
-    });
     return;
   }
 


### PR DESCRIPTION
This function should only be run its main logic if the request is a HTTP GET. By returning early instead of using `context.next(request)`, we avoid having the request go through this edge function, which will reduce the overall CPU and memory usage of this function.

Note that this behavior of returning `undefined` to bypass an Edge Function is documented behavior, it is safe to rely on this. It's documented on https://docs.netlify.com/edge-functions/api/:
```
The expected return value is one of the following:

    a standard Response object representing the HTTP response to be delivered to the client
    a standard URL object if you want to rewrite the incoming request to another same-site URL with a 200 status code
    undefined if you choose to bypass the current function
```