### PR TITLE
fix(perf): refactor the content-type check from `startsWith("text/html")` to `=== "text/html"`

### DIFF
--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -30,9 +30,7 @@ const handler = async (request: Request, context: Context) => {
 
   // html GETs only
   const isGET = request.method?.toUpperCase() === "GET";
-  const isHTMLResponse = response.headers
-    .get("content-type")
-    ?.startsWith("text/html");
+  const isHTMLResponse = response.headers.get("content-type") === "text/html";
   const shouldTransformResponse = isGET && isHTMLResponse;
   if (!shouldTransformResponse) {
     console.log(`Unnecessary invocation for ${request.url}`, {


### PR DESCRIPTION
`"text/html"` should be the only value that we act against as that is the only entry in the IANA text type registry which indicates HTML content (https://www.iana.org/assignments/media-types/media-types.xhtml#text).

Also, the HTTP header/field values can not begin or end with whitespace (https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5), which is why we can use a strict equality against the exact string "text/html".