### PR TITLE
fix: update the config to only ever run the function for HTTP GET requests

### DIFF
--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -19,21 +19,6 @@ type Params = {
 const params = inputs as Params;
 
 const handler = async (request: Request, context: Context) => {
-  const isGET = request.method === "GET";
-  // We only need to run this for HTTP GET requests.
-  // If it is not a GET, then return early.
-  //
-  // If we instead used `context.next(request)`
-  // we would be passing the request through this 
-  // edge function for no useful reason.
-  if (!isGET) {
-    return;
-  }
-
-
-  // At this point, we know it's a GET request,
-  // we have to now make the request, in order to
-  // see what the HTTP response's content-type is.
   const response = await context.next(request);
 
   let header = params.reportOnly
@@ -197,6 +182,7 @@ export const config: Config = {
   .filter(Boolean),
   handler,
   onError: "bypass",
+  method: "GET",
 };
 
 export default handler;


### PR DESCRIPTION
previously we were handling this in the function implementation by checking the method and returning early is if was not a GET.  we can do better than this however, and configure the function to only be invoked if the request method is a GET.