### PR TITLE
Revert "fix(perf): refactor the content-type check from `startsWith("text/html")` to `=== "text/html"`"

### DIFF
--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -24,8 +24,11 @@ const handler = async (request: Request, context: Context) => {
   // for debugging which routes use this edge function
   response.headers.set("x-debug-csp-nonce", "invoked");
 
-  const isHTMLResponse = response.headers.get("content-type") === "text/html";
-  if (!isHTMLResponse) {
+  const isHTMLResponse = response.headers
+    .get("content-type")
+    ?.startsWith("text/html");
+  const shouldTransformResponse = isHTMLResponse;
+  if (!shouldTransformResponse) {
     console.log(`Unnecessary invocation for ${request.url}`, {
       method: request.method,
       "content-type": response.headers.get("content-type"),


### PR DESCRIPTION
Reverts netlify/plugin-csp-nonce#85

I forgot that the content-type can include an optional charset directive, E.G. `text/html; charset=UTF-8`

We need to revert this PR to as it broke the CSP plugin - I will do a separate PR which adds a bunch of integration tests so we don't regress again