### PR TITLE
test: if origin response has a csp with a nonce, ensure we are not overriding it with a new value and that we are not adding any nonce attributes to the response body ourselves.

### DIFF
--- a/site/_headers
+++ b/site/_headers
@@ -1,2 +1,4 @@
 /
   Content-Security-Policy: img-src 'self' blob: data:; script-src 'sha256-/Cb4VxgL2aVP0MVDvbP0DgEOUv+MeNQmZX4yXHkn/c0='
+/pre-existing-csp-with-nonce.html
+  Content-Security-Policy: img-src 'self' blob: data:; script-src 'nonce-meow' 'strict-dynamic' 'unsafe-inline' 'unsafe-eval' 'self' https: http: 'sha256-/Cb4VxgL2aVP0MVDvbP0DgEOUv+MeNQmZX4yXHkn/c0='; report-uri /.netlify/functions/__csp-violations

--- a/site/pre-existing-csp-with-nonce.html
+++ b/site/pre-existing-csp-with-nonce.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <link rel="stylesheet" href="/main.css" />
+  <link class="does-not-have-nonce" rel="preload" as="script" href="https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js" />
+  <link class="has-nonce" nonce="nonce-meow" rel="preload" as="script"
+    href="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js" />
+</head>
+
+<body>
+  <script class="has-nonce" nonce="nonce-meow"
+    src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
+  <script class="does-not-have-nonce">
+    document.write("<p>❌ nay</p>");
+  </script>
+  <script class="has-nonce" nonce="nonce-meow">
+    document.write("<p>✅ yay</p>");
+    confetti();
+  </script>
+  <script class="does-not-have-nonce" nonce="nonce-meow"
+    src="https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
I think this is likely the behaviour we want to have, as it stands however, this is not what we are doing - it would be good to discuss whether this is a change we want to make to the plugin