### PR TITLE
fix: Bump csp nonce html rewriter version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1153,11 +1153,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -2,7 +2,7 @@
 // @ts-ignore
 import type { Config, Context } from "netlify:edge";
 // @ts-ignore
-import { csp } from "https://deno.land/x/csp_nonce_html_transformer@v2.1.1/src/index.ts";
+import { csp } from "https://deno.land/x/csp_nonce_html_transformer@v2.1.4/src/index.ts";
 // @ts-ignore
 import inputs from "./__csp-nonce-inputs.json" assert { type: "json" };
 

--- a/tests/integration/test.test.ts
+++ b/tests/integration/test.test.ts
@@ -263,7 +263,7 @@ describe("Origin response has html content-type but non-html text contents in bo
   let response: Response;
   beforeAll(async () => {
     response = await fetch(new URL(`/i-am-really-a-json-file.html`, baseURL));
-  });
+  }, 15000);
   
   it("__csp-nonce edge function was invoked", () => {
     expect(response.headers.get("x-debug-csp-nonce")).to.eql("invoked");


### PR DESCRIPTION
I was able to reproduce the [edge function crash](https://linear.app/netlify/issue/CPLA-2262/csp-plugin-causes-recursive-use-of-an-object-detected-which-would-lead#comment-51aafd01) issue with csp_nonce_html_transformer@v2.1.1.

With csp_nonce_html_transformer@v2.1.4 I am no longer able to reproduce and hopefully this will solve our CSP issue.

Next step would be to publish the new csp plugin and test it out on the netlify-react-ui