### PR TITLE
fix: Continue down request chain to get response

### DIFF
--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -30,12 +30,12 @@ params.self = true;
 params.https = true;
 params.http = true;
 
-const handler = async (request: Request, context: Context) => {
-  const response = await context.next(request);
+const handler = async (_request: Request, context: Context) => {
+  const response = await context.next();
 
   // for debugging which routes use this edge function
   response.headers.set("x-debug-csp-nonce", "invoked");
-  return csp(response, params)
+  return csp(response, params);
 };
 
 // Top 50 most common extensions (minus .html and .htm) according to Humio


### PR DESCRIPTION
We ran into issues with cypress tests when running in the netlify react app.

I was able to reproduce by running the react app locally and when removing the request out of `context.next()` it worked.

By default `context.next()` will continue down the request chain, which is what we want.