### PR TITLE
fix: inject function only on prebuild

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,5 +91,3 @@ export const onPreBuild = async ({
 
   console.log(`  Done.`);
 };
-
-export const onPreDev = onPreBuild;

--- a/index.js
+++ b/index.js
@@ -91,3 +91,16 @@ export const onPreBuild = async ({
 
   console.log(`  Done.`);
 };
+
+export const onPreDev = async ({ inputs, netlifyConfig, utils, constants }) => {
+  if (!process.env.RUN_NETLIFY_CSP_NONCE_PLUGIN_TESTS) {
+    return;
+  }
+
+  return onPreBuild({
+    inputs,
+    netlifyConfig,
+    utils,
+    constants,
+  });
+};

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -30,6 +30,7 @@ export const serve = async ({
   const proc = execa(...command(port), {
     all: true,
     cancelSignal: abortController.signal,
+    env: { RUN_NETLIFY_CSP_NONCE_PLUGIN_TESTS: "1" },
   });
 
   await new Promise<void>((resolve) => {


### PR DESCRIPTION
When running the plugin with the netlify-react-ui locally or running the circle ci tests would fail. This is because netlify-react-ui would run the csp edge function before the page was even bundled.

![image](https://github.com/user-attachments/assets/185fc589-7d76-4b8a-9fee-2c428bba35e9)

without this change running react-ui locally would break
