### PR TITLE
fix: use entrypoint which embeds the wasm instead of requiring it to be fetched over the network when deployed as a Netlify Edge Function

### DIFF
--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -2,7 +2,7 @@
 // @ts-ignore
 import type { Config, Context } from "netlify:edge";
 // @ts-ignore
-import { csp } from "https://deno.land/x/csp_nonce_html_transformer@v2.1.5/src/index.ts";
+import { csp } from "https://deno.land/x/csp_nonce_html_transformer@v2.2.0/src/index-embedded-wasm.ts";
 // @ts-ignore
 import inputs from "./__csp-nonce-inputs.json" assert { type: "json" };
 


### PR DESCRIPTION
Netlify Edge Functions are not able to read the file-system, which means we can't read the generated .wasm file during execution, we currently fetch the wasm file over the network but this request could fail or have an incorrect response, leading to a runtime error when attempting to instantiate the WebAssembly Module. To work-around this, the library was updated to include a .ts file which includes the exact same bytes as the wasm file, but within a JavaScript UInt8Array, which we can then instantiate as a WebAssembly Module.

This will resolve the occassional errors we see along the lines of:
>**Unhandled error**
>CompileError: WebAssembly.instantiate(): expected magic word 00 61 73 6d, found 35 30 30 3a @+0
>**Location**
>https://deno.land/x/csp_nonce_html_transformer@v2.1.5/pkg/html_rewriter.js:337 - __wbg_load