### PR TITLE
fix: update @netlify/build-info to v8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
-        "@netlify/build-info": "^7.15.2"
+        "@netlify/build-info": "^8.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.9.0",
@@ -509,10 +509,9 @@
       "license": "MIT"
     },
     "node_modules/@netlify/build-info": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@netlify/build-info/-/build-info-7.15.2.tgz",
-      "integrity": "sha512-z249vRTIyeO1Coaa2UaaZJpTN2D9mE0HPvuQfVknJ+WqHdLjPHlmaKu2HyekfnA5zE8mVSkPAJsP9dip3kySSg==",
-      "license": "MIT",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@netlify/build-info/-/build-info-8.0.0.tgz",
+      "integrity": "sha512-WwExAgIkyznvT55bvS2G0Kk8s+jC/e/3KzrQhSXVrvDunfVRXi66xcIKzaKUcaqnC45odqJXfYs++w4P7QK2xw==",
       "dependencies": {
         "@bugsnag/js": "^7.20.0",
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@netlify/build-info": "^7.15.2"
+    "@netlify/build-info": "^8.0.0"
   }
 }


### PR DESCRIPTION
The breaking changes in `@netlify/build-info` don't impact usage in this plugin https://github.com/netlify/plugin-csp-nonce/blob/4f1e0855c39a90a1f524608e5b95c6f3420ffaf5/index.js#L10

So this is just to ensure ~latest is being used to not miss any potential future updates.

https://github.com/netlify/build/pull/5962 was change requiring major version bump