### PR TITLE
feat: allow self and unsafeInline as inputs

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -14,3 +14,9 @@ inputs:
   - name: excludedPath
     description: The glob expressions of path(s) that *should not* invoke the CSP nonce edge function. Must be an array of strings. This value gets spread with common non-html filetype extensions (*.css, *.js, *.svg, etc)
     default: []
+  - name: unsafeInline
+    description: When true, allows the execution of inline scripts, such as those defined within <script> tags or through onclick attributes.
+    default: true
+  - name: self
+    description: When true, restricts the execution of scripts to those that originate from the same origin (protocol, domain, and port) as the document.
+    default: true

--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -25,8 +25,8 @@ params.reportUri = params.reportUri || "/.netlify/functions/__csp-violations";
 params.distribution = Netlify.env.get("CSP_NONCE_DISTRIBUTION");
 
 params.strictDynamic = true;
-params.unsafeInline = true;
-params.self = true;
+params.unsafeInline = params.unsafeInline ?? true;
+params.self = params.self ?? true;
 params.https = true;
 params.http = true;
 


### PR DESCRIPTION
This allows our users to define themselves if they want to allow self and unsafeInline as inputs or not. As we now set them as true by default. 