### PR TITLE
fix: allow http and https to be optional

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -25,7 +25,7 @@ inputs:
     default: true
   - name: https
     description: When true, allows execution of scripts from https origins.
-    default: false
+    default: true
   - name: http
     description: When true, allows execution of scripts from http origins.
-    default: false
+    default: true

--- a/src/__csp-nonce.ts
+++ b/src/__csp-nonce.ts
@@ -33,8 +33,8 @@ params.distribution = Netlify.env.get("CSP_NONCE_DISTRIBUTION");
 params.strictDynamic = params.strictDynamic ?? true;
 params.unsafeInline = params.unsafeInline ?? true;
 params.self = params.self ?? true;
-params.https = true;
-params.http = true;
+params.https = params.https ?? true;
+params.http = params.http ?? true;
 
 const handler = async (_request: Request, context: Context) => {
   try {


### PR DESCRIPTION
We already accepted this as a config option in the manifest, but in the code, we were forcing this to be true. One of our customers would like to be able to disable this: https://netlify.slack.com/archives/C030NUD520Y/p1772108960562419